### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,25 +10,25 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mustermann (1.0.1)
+    mustermann (1.0.2)
     netrc (0.11.0)
-    puma (3.11.0)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    puma (3.11.2)
+    rack (2.0.4)
+    rack-protection (2.0.1)
       rack
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    sinatra (2.0.0)
+    sinatra (2.0.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.1)
       tilt (~> 2.0)
     tilt (2.0.8)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Warning de Github sobre sinatra. Se actualizó a versión 2.0.1 a través de 'bundle update'